### PR TITLE
Add prepublish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "rimraf build && tsc",
     "test": "jest",
+    "clean": "rimraf build",
+    "prepublish": "npm run clean && npm run build",
     "test-coverage": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "lint": "eslint src --ext .ts,.js",
     "lint:fix": "eslint --fix . --ext .ts,.js",


### PR DESCRIPTION
Make sure the build dir is updated before publishing the NPM package

This is a first step PR, we'll evolve this so it's easier to generate versions in the future. We'll end up using travis, that would detect a new tag and do the build/npm-publish on it's own

@nlordell is doing the same for `dex-contracts`, so we would apply the same solution/script here.