### PR TITLE
WIP: Update TS definitions for latest contracts

### DIFF
--- a/src/contracts/BatchExchangeContract.ts
+++ b/src/contracts/BatchExchangeContract.ts
@@ -33,14 +33,14 @@ export interface Deposit {
   user: string
   token: string
   amount: string
-  stateIndex: string
+  batchId: string
 }
 
 export interface WithdrawRequest {
   user: string
   token: string
   amount: string
-  stateIndex: string
+  batchId: string
 }
 
 export interface Withdraw {

--- a/src/contracts/gen/BatchExchange.ts
+++ b/src/contracts/gen/BatchExchange.ts
@@ -30,7 +30,7 @@ export interface BatchExchange extends Contract {
     ): TransactionObject<string>
 
     submitSolution(
-      batchIndex: number | string,
+      batchId: number | string,
       claimedObjectiveValue: number | string,
       owners: string[],
       orderIds: (number | string)[],
@@ -107,7 +107,7 @@ export interface BatchExchange extends Contract {
 
     cancelOrders(ids: (number | string)[]): TransactionObject<void>
 
-    acceptingSolutions(batchIndex: number | string): TransactionObject<boolean>
+    acceptingSolutions(batchId: number | string): TransactionObject<boolean>
 
     getEncodedAuctionElements(): TransactionObject<string>
 
@@ -164,7 +164,7 @@ export interface BatchExchange extends Contract {
       user: string
       token: string
       amount: string
-      stateIndex: string
+      batchId: string
       0: string
       1: string
       2: string
@@ -174,7 +174,7 @@ export interface BatchExchange extends Contract {
       user: string
       token: string
       amount: string
-      stateIndex: string
+      batchId: string
       0: string
       1: string
       2: string

--- a/src/contracts/gen/BatchExchange.ts
+++ b/src/contracts/gen/BatchExchange.ts
@@ -51,7 +51,7 @@ export interface BatchExchange extends Contract {
 
     getPendingWithdrawBatchNumber(user: string, token: string): TransactionObject<string>
 
-    TOKEN_ADDITION_FEE_IN_OWL(): TransactionObject<string>
+    FEE_FOR_LISTING_TOKEN_IN_OWL(): TransactionObject<string>
 
     AMOUNT_MINIMUM(): TransactionObject<string>
 

--- a/src/contracts/gen/BatchExchange.ts
+++ b/src/contracts/gen/BatchExchange.ts
@@ -19,7 +19,7 @@ export interface BatchExchange extends Contract {
   methods: {
     getSecondsRemainingInBatch(): TransactionObject<string>
 
-    feeDenominator(): TransactionObject<string>
+    FEE_DENOMINATOR(): TransactionObject<string>
 
     placeOrder(
       buyToken: number | string,

--- a/test/sandbox/contracts/getPastDeposits.ts
+++ b/test/sandbox/contracts/getPastDeposits.ts
@@ -15,13 +15,13 @@ async function exec (): Promise<void> {
 
   log.info('Found %d deposits', events.length)
   events.forEach(depositEvent => {
-    const { user, token, amount, stateIndex } = depositEvent.returnValues
+    const { user, token, amount, batchId } = depositEvent.returnValues
     log.info(
-      'New Deposit of user %s\n\tAmount: %s\n\tToken: %s\n\tState index: %s\n\tTransaction: %s',
+      'New Deposit of user %s\n\tAmount: %s\n\tToken: %s\n\tBatch ID: %s\n\tTransaction: %s',
       user,
       amount,
       token,
-      stateIndex,
+      batchId,
       depositEvent.transactionHash
     )
   })


### PR DESCRIPTION


**Change summary**

- `feeDenominator` has become constant and is now `FEE_DENOMINATOR`
- all occurrences of `stateIndex` and `batchIndex` have been unified to `batchId`
- rename `FEE_FOR_LISTING_TOKEN_IN_OWL`

**TODO?**

- Do new events need to be included? If so... what were they
- new, paginated, version of `getUserOrders` (`getEncodedUserOrdersPaginated`)
- `replaceOrders`


Note I was on vacation for two weeks and may be missing some crutial changes. Please speak up if there are any items I do not appear to be aware of.

