### PR TITLE
Fix linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ yarn install
 
 # Build
 yarn build
+
+# Build and watch (useful when using "npm link")
+yarn build:watch
 ```
 
 ## Run test

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "build": "rimraf build && ttsc && cp -r src/contracts/gen build/contracts/",
+    "build:watch": "npx ttsc --watch",
     "test": "jest",
     "clean": "rimraf build",
     "prepublish": "npm run clean && npm run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-js",
-  "version": "0.1.5-RC.3",
+  "version": "0.1.5",
   "description": "dFusion JS integration: utils, contracts and other goodies",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-js",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "dFusion JS integration: utils, contracts and other goodies",
   "license": "MIT",
   "bugs": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
+import { AbiItem } from 'web3-utils'
 import { TokenDetailsConfig } from 'types'
 import tokenListJson from 'tokenList.json'
+import { abi } from '@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json'
 
 // Contracts
 export * from './contracts'
@@ -14,3 +16,6 @@ export * from './utils'
 
 // Json list
 export const tokenList: TokenDetailsConfig[] = tokenListJson
+
+// Re-export ABI
+export const batchExchangeAbi: AbiItem[] = abi as AbiItem[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
-import { AbiItem } from 'web3-utils'
 import { TokenDetailsConfig } from 'types'
 import tokenListJson from 'tokenList.json'
-import { abi } from '@gnosis.pm/dex-contracts/build/contracts/BatchExchange.json'
 
 // Contracts
 export * from './contracts'
@@ -16,6 +14,3 @@ export * from './utils'
 
 // Json list
 export const tokenList: TokenDetailsConfig[] = tokenListJson
-
-// Re-export ABI
-export const batchExchangeAbi: AbiItem[] = abi as AbiItem[]


### PR DESCRIPTION
Reexport the abi and adds a script that is handy for using dex-js linked to a project that depends on it.

This changes comes from debugging with leandro why linking projects where not working.