### PR TITLE
isUnlimitedOrder now accepts BigNumber and string params plus tests

### DIFF
--- a/src/utils/orders.ts
+++ b/src/utils/orders.ts
@@ -1,5 +1,14 @@
 import BN from 'bn.js'
+import BigNumber from 'bignumber.js'
 import { UNLIMITED_ORDER_AMOUNT } from 'const'
+
+function amountToString(amount: BN | BigNumber | string): string {
+  if (typeof amount === 'string') {
+    return amount
+  } else {
+    return amount.toString(10)
+  }
+}
 
 /**
  * Checks whether values for given order qualifies it as an unlimited order.
@@ -11,6 +20,8 @@ import { UNLIMITED_ORDER_AMOUNT } from 'const'
  * @param amount1 Price numerator
  * @param amount2 Price denominator
  */
-export function isOrderUnlimited(amount1: BN, amount2: BN): boolean {
-  return amount1 === UNLIMITED_ORDER_AMOUNT || amount2 === UNLIMITED_ORDER_AMOUNT
+export function isOrderUnlimited(amount1: BN | BigNumber | string, amount2: BN | BigNumber | string): boolean {
+  // Easier to always compare as string regardless of the type passed in
+  const unlimitedAmount = amountToString(UNLIMITED_ORDER_AMOUNT)
+  return amountToString(amount1) === unlimitedAmount || amountToString(amount2) === unlimitedAmount
 }

--- a/test/utils/orders.spec.ts
+++ b/test/utils/orders.spec.ts
@@ -1,0 +1,38 @@
+import BN from 'bn.js'
+import BigNumber from 'bignumber.js'
+
+import { UNLIMITED_ORDER_AMOUNT } from '../../src'
+import { isOrderUnlimited } from '../../src'
+
+describe('Compare string values', () => {
+  const unlimitedValue = UNLIMITED_ORDER_AMOUNT.toString()
+
+  test('is unlimited', () => {
+    expect(isOrderUnlimited(unlimitedValue, '0')).toBeTruthy()
+  })
+  test('is NOT unlimited', () => {
+    expect(isOrderUnlimited('2', '0')).toBeFalsy()
+  })
+})
+
+describe('Compare BN values', () => {
+  const unlimitedValue = UNLIMITED_ORDER_AMOUNT
+
+  test('is unlimited', () => {
+    expect(isOrderUnlimited(unlimitedValue, new BN(1))).toBeTruthy()
+  })
+  test('is NOT unlimited', () => {
+    expect(isOrderUnlimited(new BN(10), new BN(35345))).toBeFalsy()
+  })
+})
+
+describe('Compare string values', () => {
+  const unlimitedValue = new BigNumber(UNLIMITED_ORDER_AMOUNT.toString())
+
+  test('is unlimited', () => {
+    expect(isOrderUnlimited(unlimitedValue, new BigNumber(0))).toBeTruthy()
+  })
+  test('is NOT unlimited', () => {
+    expect(isOrderUnlimited(new BigNumber(1923810), new BigNumber(4))).toBeFalsy()
+  })
+})


### PR DESCRIPTION
Per title, isUnlimitedOrder now accepts BigNumber and string params plus tests

dex-react has order amounts as `BN`, while dex-telegram has them as `BigNumber`.

Added string as a bonus just in case.