### PR TITLE
Format amount locale aware

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "npm run build:commonjs && npm run build:esm",
     "build:commonjs": "rimraf build && ttsc && cp -r src/contracts/gen build/contracts/",
-    "build:esm": "rimraf build-esm && ttsc -m es6 -t esnext --outDir build-esm && cp -r src/contracts/gen build-esm/contracts/",
+    "build:esm": "rimraf build-esm && ttsc -m esnext -t es2015 --outDir build-esm && cp -r src/contracts/gen build-esm/contracts/",
     "build:watch": "npx ttsc --watch",
     "test": "jest",
     "clean": "rimraf build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-js",
-  "version": "0.1.14",
+  "version": "0.1.15-RC.0",
   "description": "dFusion JS integration: utils, contracts and other goodies",
   "license": "MIT",
   "bugs": {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -4,6 +4,7 @@ import { TokenDetails } from 'types'
 import BigNumber from 'bignumber.js'
 const DEFAULT_DECIMALS = 4
 const ELLIPSIS = '...'
+
 function _getLocaleSymbols(): { thousands: string; decimals: string } {
   // Check number representation in default locale
   const formattedNumber = new Intl.NumberFormat(undefined).format(1000.1)
@@ -12,10 +13,13 @@ function _getLocaleSymbols(): { thousands: string; decimals: string } {
     decimals: formattedNumber[5],
   }
 }
+
 const { thousands: THOUSANDS_SYMBOL, decimals: DECIMALS_SYMBOL } = _getLocaleSymbols()
+
 function _formatNumber(num: string): string {
   return num.replace(/(\d)(?=(?:\d{3})+(?!\d))/g, '$1' + THOUSANDS_SYMBOL)
 }
+
 function _decomposeBn(amount: BN, amountPrecision: number, decimals: number): { integerPart: BN; decimalPart: BN } {
   // Discard the decimals we don't need
   //  i.e. for WETH (precision=18, decimals=4) --> amount / 1e14
@@ -31,6 +35,7 @@ function _decomposeBn(amount: BN, amountPrecision: number, decimals: number): { 
   //        1, 18:  16.5*1e18 ---> 165000
   return { integerPart, decimalPart }
 }
+
 export function formatAmount(
   amount: BN,
   amountPrecision: number,
@@ -67,6 +72,7 @@ export function formatAmount(
     return integerPartFmt + DECIMALS_SYMBOL + decimalFmt
   }
 }
+
 export function formatAmountFull(amount: BN, amountPrecision?: number, thousandSeparator?: boolean): string
 export function formatAmountFull(amount?: undefined): null
 export function formatAmountFull(
@@ -79,6 +85,7 @@ export function formatAmountFull(
   }
   return formatAmount(amount, amountPrecision, amountPrecision, thousandSeparator)
 }
+
 /**
  * Adjust the decimal precision of the given decimal value, without converting to/from BN or Number
  * Takes in a string and returns a string
@@ -96,6 +103,7 @@ export function adjustPrecision(value: string | undefined | null, precision: num
   const regexp = new RegExp(`(\\.\\d{${precision}})\\d+$`)
   return value.replace(regexp, '$1')
 }
+
 export function parseAmount(amountFmt: string, amountPrecision: number): BN | null {
   if (!amountFmt) {
     return null
@@ -111,6 +119,7 @@ export function parseAmount(amountFmt: string, amountPrecision: number): BN | nu
     return null
   }
 }
+
 export function abbreviateString(inputString: string, prefixLength: number, suffixLength = 0): string {
   // abbreviate only if it makes sense, and make sure ellipsis fits into word
   // 1. always add ellipsis
@@ -125,9 +134,11 @@ export function abbreviateString(inputString: string, prefixLength: number, suff
   const suffix = suffixLength > 0 ? inputString.slice(-suffixLength) : ''
   return prefix + ELLIPSIS + suffix
 }
+
 export function safeTokenName(token: TokenDetails): string {
   return token.symbol || token.name || abbreviateString(token.address, 6, 4)
 }
+
 export function safeFilledToken<T extends TokenDetails>(token: T): T {
   return {
     ...token,

--- a/test/utils/format/formatAmount.spec.ts
+++ b/test/utils/format/formatAmount.spec.ts
@@ -187,3 +187,10 @@ describe('Edge cases', () => {
     expect(formatAmount({ amount, precision: 2, decimals: 4 })).toEqual('12,345.67')
   })
 })
+
+describe('Not locale aware', () => {
+  test('12,345.67 - More decimals, than precision', async () => {
+    const amount = new BN('1234567')
+    expect(formatAmount({ amount, precision: 2, decimals: 4, isLocaleAware: false })).toEqual('12,345.67')
+  })
+})

--- a/test/utils/format/formatAmount.spec.ts
+++ b/test/utils/format/formatAmount.spec.ts
@@ -127,44 +127,44 @@ describe('Tokens with precision 2', () => {
 describe('2 decimals', () => {
   test('1 unit', async () => {
     const amount = new BN('1000000')
-    expect(formatAmount(amount, 6, 2)).toEqual('1')
+    expect(formatAmount({ amount, precision: 6, decimals: 2 })).toEqual('1')
   })
 
   test('12.34 units', async () => {
     const amount = new BN('12340000')
-    expect(formatAmount(amount, 6, 2)).toEqual('12.34')
+    expect(formatAmount({ amount, precision: 6, decimals: 2 })).toEqual('12.34')
   })
 
   test('4,567,890.123333 units, round down', async () => {
     const amount = new BN('4567890123333')
-    expect(formatAmount(amount, 6, 2)).toEqual('4,567,890.12')
+    expect(formatAmount({ amount, precision: 6, decimals: 2 })).toEqual('4,567,890.12')
   })
 
   test('4,567,890.125555 units, round up', async () => {
     const amount = new BN('4567890125555')
-    expect(formatAmount(amount, 6, 2)).toEqual('4,567,890.13')
+    expect(formatAmount({ amount, precision: 6, decimals: 2 })).toEqual('4,567,890.13')
   })
 })
 
 describe('0 decimals', () => {
   test('1 unit', async () => {
     const amount = new BN('1000000')
-    expect(formatAmount(amount, 6, 0)).toEqual('1')
+    expect(formatAmount({ amount, precision: 6, decimals: 0 })).toEqual('1')
   })
 
   test('12.34 units', async () => {
     const amount = new BN('12340000')
-    expect(formatAmount(amount, 6, 0)).toEqual('12')
+    expect(formatAmount({ amount, precision: 6, decimals: 0 })).toEqual('12')
   })
 
   test('4,567,890.123333 units, round down', async () => {
     const amount = new BN('4567890123333')
-    expect(formatAmount(amount, 6, 0)).toEqual('4,567,890')
+    expect(formatAmount({ amount, precision: 6, decimals: 0 })).toEqual('4,567,890')
   })
 
   test('4,567,890.125555 units, round up', async () => {
     const amount = new BN('4567890125555')
-    expect(formatAmount(amount, 6, 0)).toEqual('4,567,890')
+    expect(formatAmount({ amount, precision: 6, decimals: 0 })).toEqual('4,567,890')
   })
 })
 
@@ -182,8 +182,8 @@ describe('Big amounts', () => {
 })
 
 describe('Edge cases', () => {
-  test('12,345.67 - More decimals, than precission', async () => {
+  test('12,345.67 - More decimals, than precision', async () => {
     const amount = new BN('1234567')
-    expect(formatAmount(amount, 2, 4)).toEqual('12,345.67')
+    expect(formatAmount({ amount, precision: 2, decimals: 4 })).toEqual('12,345.67')
   })
 })

--- a/test/utils/format/formatAmountFull.spec.ts
+++ b/test/utils/format/formatAmountFull.spec.ts
@@ -1,21 +1,21 @@
 import BN from 'bn.js'
-import { formatAmountFull, toWei, ZERO, ONE, ALLOWANCE_MAX_VALUE, DEFAULT_PRECISION } from '../../../src'
+import { formatAmountFull, toWei, ZERO, ONE, ALLOWANCE_MAX_VALUE } from '../../../src'
 
 describe('Integer amounts', () => {
   test('1 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('1'), 'ether')), DEFAULT_PRECISION)).toEqual('1')
+    expect(formatAmountFull(new BN(toWei(new BN('1'), 'ether')))).toEqual('1')
   })
 
   test('12,345 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('12345'), 'ether')), DEFAULT_PRECISION)).toEqual('12,345')
+    expect(formatAmountFull(new BN(toWei(new BN('12345'), 'ether')))).toEqual('12,345')
   })
 
   test('0100 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('0100'), 'ether')), DEFAULT_PRECISION)).toEqual('100')
+    expect(formatAmountFull(new BN(toWei(new BN('0100'), 'ether')))).toEqual('100')
   })
 
   test('123,456,789,012 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('123456789012'), 'ether')), DEFAULT_PRECISION)).toEqual(
+    expect(formatAmountFull(new BN(toWei(new BN('123456789012'), 'ether')))).toEqual(
       '123,456,789,012',
     )
   })
@@ -23,67 +23,67 @@ describe('Integer amounts', () => {
 
 describe('Exact decimal amounts', () => {
   test('0.5 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('500'), 'milliether')), DEFAULT_PRECISION)).toEqual('0.5')
+    expect(formatAmountFull(new BN(toWei(new BN('500'), 'milliether')))).toEqual('0.5')
   })
 
   test('1.234 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('1234'), 'milliether')), DEFAULT_PRECISION)).toEqual('1.234')
+    expect(formatAmountFull(new BN(toWei(new BN('1234'), 'milliether')))).toEqual('1.234')
   })
 
   test('1.2345 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('1234500'), 'microether')), DEFAULT_PRECISION)).toEqual('1.2345')
+    expect(formatAmountFull(new BN(toWei(new BN('1234500'), 'microether')))).toEqual('1.2345')
   })
 })
 
 describe('Rounding amounts', () => {
   test('0', async () => {
-    expect(formatAmountFull(ZERO, DEFAULT_PRECISION)).toEqual('0')
+    expect(formatAmountFull(ZERO)).toEqual('0')
   })
 
   test('1 wei', async () => {
-    expect(formatAmountFull(ONE, DEFAULT_PRECISION)).toEqual('0.000000000000000001')
+    expect(formatAmountFull(ONE)).toEqual('0.000000000000000001')
   })
 
   test('1000 wei', async () => {
-    expect(formatAmountFull(new BN('1000'), DEFAULT_PRECISION)).toEqual('0.000000000000001')
+    expect(formatAmountFull(new BN('1000'))).toEqual('0.000000000000001')
   })
 
   test('1.23451 Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('1234510'), 'microether')), DEFAULT_PRECISION)).toEqual('1.23451')
+    expect(formatAmountFull(new BN(toWei(new BN('1234510'), 'microether')))).toEqual('1.23451')
   })
 
   test('1.234567890123456789 Ether', async () => {
-    expect(formatAmountFull(new BN('1234567890123456789'), DEFAULT_PRECISION)).toEqual('1.234567890123456789')
+    expect(formatAmountFull(new BN('1234567890123456789'))).toEqual('1.234567890123456789')
   })
 })
 
 describe('Tokens with precision 6', () => {
   test('1 unit', async () => {
     const amount = new BN('1000000')
-    expect(formatAmountFull(amount, 6)).toEqual('1')
+    expect(formatAmountFull({ amount, precision: 6 })).toEqual('1')
   })
 
   test('12,345 units', async () => {
     const amount = new BN('12345000000')
-    expect(formatAmountFull(amount, 6)).toEqual('12,345')
+    expect(formatAmountFull({ amount, precision: 6 })).toEqual('12,345')
   })
 
   test('4,567,890.123444 units, round down', async () => {
     const amount = new BN('4567890123444')
-    expect(formatAmountFull(amount, 6)).toEqual('4,567,890.123444')
+    expect(formatAmountFull({ amount, precision: 6 })).toEqual('4,567,890.123444')
   })
 })
 
 describe('Big amounts', () => {
   // TODO: Considering showing K,M,B,...
   test('1B Ether', async () => {
-    expect(formatAmountFull(new BN(toWei(new BN('1000000000'), 'ether')), DEFAULT_PRECISION)).toEqual('1,000,000,000')
+    expect(formatAmountFull(new BN(toWei(new BN('1000000000'), 'ether')))).toEqual('1,000,000,000')
   })
 
   // TODO: Define what for arbitrarily big amounts
   test('uint max value', async () => {
     const expected =
       '115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457.584007913129639935'
-    expect(formatAmountFull(new BN(new BN(ALLOWANCE_MAX_VALUE)), DEFAULT_PRECISION)).toEqual(expected)
+    expect(formatAmountFull(new BN(new BN(ALLOWANCE_MAX_VALUE)))).toEqual(expected)
   })
 })

--- a/test/utils/format/formatAmountFull.spec.ts
+++ b/test/utils/format/formatAmountFull.spec.ts
@@ -87,3 +87,10 @@ describe('Big amounts', () => {
     expect(formatAmountFull(new BN(new BN(ALLOWANCE_MAX_VALUE)))).toEqual(expected)
   })
 })
+
+describe('Not locale aware', () => {
+  test('12,345.123 units', async () => {
+    const amount = new BN('12345123000')
+    expect(formatAmountFull({ amount, precision: 6, isLocaleAware: false })).toEqual('12,345.123')
+  })
+})


### PR DESCRIPTION
Part of https://github.com/gnosis/dex-react/issues/691

Updated interface of `formatAmount` and `formatAmountFull` to use object params and to optionally 
not use locale aware numbers.