### PR TITLE
Update tokenList.json WBTC entry

### DIFF
--- a/src/tokenList.json
+++ b/src/tokenList.json
@@ -132,7 +132,7 @@
     "id": 11,
     "name": "Wrapped BTC",
     "symbol": "WBTC",
-    "decimals": 18,
+    "decimals": 8,
     "addressByNetwork": {
       "1": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
     },


### PR DESCRIPTION
digits were incorrect. cf.:
https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599