### PR TITLE
Fix format price

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-js",
-  "version": "0.4.0",
+  "version": "0.4.1-RC.0",
   "description": "Gnosis Protocol JS integration: utils, contracts and other goodies",
   "license": "MIT",
   "bugs": {

--- a/src/const.ts
+++ b/src/const.ts
@@ -12,6 +12,7 @@ export const BN_10M = new BN('10000000')
 export const BN_1B = new BN('1000000000')
 export const BN_1T = new BN('1000000000000')
 // BigNumber
+export const ZERO_BIG_NUMBER = new BigNumber(0)
 export const ONE_BIG_NUMBER = new BigNumber(1)
 export const TEN_BIG_NUMBER = new BigNumber(10)
 

--- a/test/utils/format/formatPrice.spec.ts
+++ b/test/utils/format/formatPrice.spec.ts
@@ -109,4 +109,62 @@ describe('with single parameter', () => {
 
     expect(actual).toEqual('0.0074')
   })
+
+  test('00999 after decimal separator', () => {
+    const price = new BigNumber('0.00999')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('0.0100')
+  })
+  test('09999 after decimal separator', () => {
+    const price = new BigNumber('0.09999')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('0.1000')
+  })
+  test('89999 after decimal separator', () => {
+    const price = new BigNumber('0.89999')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('0.9000')
+  })
+
+  test('9999 after decimal separator', () => {
+    const price = new BigNumber('0.9999')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('0.9999')
+  })
+  test('99994 after decimal separator', () => {
+    const price = new BigNumber('0.99994')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('0.9999')
+  })
+  test('99995 after decimal separator', () => {
+    const price = new BigNumber('0.99995')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('1.0000')
+  })
+  test('rounding up 99998 after decimal separator', () => {
+    const price = new BigNumber('0.99998')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('1.0000')
+  })
+  test('rounding up 1.99998', () => {
+    const price = new BigNumber('1.99998')
+
+    const actual = formatPrice(price)
+
+    expect(actual).toEqual('2.0000')
+  })
 })


### PR DESCRIPTION
`formatPrice` was rounding numbers like `0.99999` wrong.
It was failing to increment integer, resulting in `0.1000`

Issue in gnosis/dex-react#1129