### PR TITLE
Format smart now accepts string as amount

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -153,16 +153,20 @@ function _decomposeBn(
  * to avoid numbers with exponents which BN also doesn't like
  *
  * @param amountStr Amount with arbitrary precision
- * @param amountPrecision precision on top of existing precision
+ * @param additionalPrecision Optional precision to add on top of existing precision
  */
-function _stringToBn(amountStr: string, amountPrecision: number): { amount: BN; precision: number } {
+export function stringToBn(amountStr: string, additionalPrecision = 0): { amount: BN | null; precision: number } {
+  if (!amountStr || isNaN(+amountStr)) {
+    return { amount: null, precision: 0 }
+  }
+
   const bigNumberAmount = new BigNumber(amountStr)
 
   const decimalPlaces = bigNumberAmount.decimalPlaces()
 
   const amount = new BN(bigNumberAmount.multipliedBy(TEN_BIG_NUMBER.pow(decimalPlaces)).integerValue().toString(10))
 
-  const precision = decimalPlaces + amountPrecision
+  const precision = decimalPlaces + additionalPrecision
 
   return { amount, precision }
 }
@@ -213,12 +217,22 @@ export function formatSmart(
     amount = params
     precision = _amountPrecision as number
   } else if (typeof params === 'string') {
-    const { amount: _amount, precision: _precision } = _stringToBn(params, _amountPrecision as number)
+    const { amount: _amount, precision: _precision } = stringToBn(params, _amountPrecision as number)
+
+    if (!_amount) {
+      return null
+    }
+
     amount = _amount
     precision = _precision
   } else {
     if (typeof params.amount === 'string') {
-      const { amount: _amount, precision: _precision } = _stringToBn(params.amount, params.precision)
+      const { amount: _amount, precision: _precision } = stringToBn(params.amount, params.precision)
+
+      if (!_amount) {
+        return null
+      }
+
       amount = _amount
       precision = _precision
     } else {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -40,13 +40,16 @@ function _formatDecimalsForDisplay(numberToConvert: BigNumber) {
   return integer + DEFAULT_DECIMALS_SYMBOL + decimalsWithoutIntegerOrSymbol
 }
 
-function _decomposeLargeNumberToString(
-  baseUnit: BN,
-  baseUnitsPerRepresentationUnits: BN,
-): string {
+function _decomposeLargeNumberToString(baseUnit: BN, baseUnitsPerRepresentationUnits: BN): string {
   // e.g TRILLION_123_123.div(ONE_TRILLION) = 123123.123123123
-  const baseUnitAsDecimal = baseUnit.mul(TEN.pow(new BN(DEFAULT_LARGE_NUMBER_PRECISION))).div(baseUnitsPerRepresentationUnits)
-  const { integerPart, decimalPart } = _decomposeBn(baseUnitAsDecimal, DEFAULT_LARGE_NUMBER_PRECISION, DEFAULT_LARGE_NUMBER_PRECISION)
+  const baseUnitAsDecimal = baseUnit
+    .mul(TEN.pow(new BN(DEFAULT_LARGE_NUMBER_PRECISION)))
+    .div(baseUnitsPerRepresentationUnits)
+  const { integerPart, decimalPart } = _decomposeBn(
+    baseUnitAsDecimal,
+    DEFAULT_LARGE_NUMBER_PRECISION,
+    DEFAULT_LARGE_NUMBER_PRECISION,
+  )
   // 123123.123123123 = 123,123.123123123
   const formattedInteger = _formatNumber(integerPart.toString(10), THOUSANDS_SYMBOL)
   // no relevant decimal section
@@ -69,10 +72,7 @@ interface DecomposedNumberParts {
   decimalsPadded: string
 }
 
-function _formatSmart(
-  { integerPart, decimalPart, decimalsPadded }: DecomposedNumberParts,
-  smallLimit: string,
-): string {
+function _formatSmart({ integerPart, decimalPart, decimalsPadded }: DecomposedNumberParts, smallLimit: string): string {
   // Is < 1
   if (integerPart.isZero()) {
     // if amount < 1 and decimal < smallLimit
@@ -80,7 +80,9 @@ function _formatSmart(
     // else return decimals as is
     const ourDecimalsAsBigNumber = new BigNumber('0.' + decimalsPadded)
     const smallLimitAsBigNumber = new BigNumber(smallLimit)
-    return ourDecimalsAsBigNumber.isLessThan(smallLimitAsBigNumber) ? `< ${_formatDecimalsForDisplay(smallLimitAsBigNumber)}` : ourDecimalsAsBigNumber.toString(10)
+    return ourDecimalsAsBigNumber.isLessThan(smallLimitAsBigNumber)
+      ? `< ${_formatDecimalsForDisplay(smallLimitAsBigNumber)}`
+      : ourDecimalsAsBigNumber.toString(10)
   }
 
   // Number compacting logic
@@ -118,7 +120,11 @@ function _formatSmart(
   return adjustPrecision(amountBeforePrecisionCheck, finalPrecision).replace(/0+$/, '')
 }
 
-function _decomposeBn(amount: BN, amountPrecision: number, decimals: number): { integerPart: BN; decimalPart: BN, decimalsPadded: string } {
+function _decomposeBn(
+  amount: BN,
+  amountPrecision: number,
+  decimals: number,
+): { integerPart: BN; decimalPart: BN; decimalsPadded: string } {
   if (decimals > amountPrecision) {
     throw new Error('The decimals cannot be bigger than the precision')
   }
@@ -178,7 +184,7 @@ export function formatSmart(params: SmartFormatParams<BN>): string
 export function formatSmart(params: SmartFormatParams<string>): string
 export function formatSmart(params: SmartFormatParams<null | undefined>): null
 export function formatSmart(
-  params: SmartFormatParams<BN | string | null | undefined> | BN| string| null | undefined,
+  params: SmartFormatParams<BN | string | null | undefined> | BN | string | null | undefined,
   _amountPrecision?: number,
 ): string | null {
   /*
@@ -195,7 +201,13 @@ export function formatSmart(
   let decimals = DEFAULT_DECIMALS
   let smallLimit = DEFAULT_SMALL_LIMIT
 
-  if (!params || (typeof params === 'string' && isNaN(+params)) || (typeof params !== 'string' && 'amount' in params && !params.amount)) return null
+  if (
+    !params ||
+    (typeof params === 'string' && isNaN(+params)) ||
+    (typeof params !== 'string' && 'amount' in params && !params.amount)
+  ) {
+    return null
+  }
 
   if (BN.isBN(params)) {
     amount = params
@@ -368,7 +380,7 @@ export function abbreviateString(inputString: string, prefixLength: number, suff
   return prefix + ELLIPSIS + suffix
 }
 
-type MinimalSafeToken = Pick<TokenDex, 'symbol' | 'name'| 'address'>
+type MinimalSafeToken = Pick<TokenDex, 'symbol' | 'name' | 'address'>
 
 export function safeTokenName(token: MinimalSafeToken): string {
   return token.symbol || token.name || abbreviateString(token.address, 6, 4)
@@ -431,10 +443,10 @@ export function formatPrice(params: FormatPriceParams | BigNumber): string {
   let integerPart = price.integerValue(BigNumber.ROUND_FLOOR)
 
   const priceMinusIntPart = price
-  // adjust decimal precision: 5.516; decimals 2 => 5.52
-  // keep in mind there's rounding
+    // adjust decimal precision: 5.516; decimals 2 => 5.52
+    // keep in mind there's rounding
     .decimalPlaces(decimals, BigNumber.ROUND_HALF_CEIL)
-  // remove integer part: 5.52 => 0.52
+    // remove integer part: 5.52 => 0.52
     .minus(integerPart)
 
   let decimalPart: BigNumber
@@ -447,7 +459,7 @@ export function formatPrice(params: FormatPriceParams | BigNumber): string {
     decimalPart = ZERO_BIG_NUMBER
   } else {
     decimalPart = priceMinusIntPart
-    // turn decimals into integer: 0.52 -> 52
+      // turn decimals into integer: 0.52 -> 52
       .shiftedBy(decimals)
   }
 

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -149,18 +149,14 @@ function _decomposeBn(amount: BN, amountPrecision: number, decimals: number): { 
  * @param amountStr Amount with arbitrary precision
  * @param amountPrecision precision on top of existing precision
  */
-function _stringToBn(amountStr:string, amountPrecision:number):{ amount: BN, precision: number } {
+function _stringToBn(amountStr: string, amountPrecision: number): { amount: BN; precision: number } {
   const bigNumberAmount = new BigNumber(amountStr)
 
-  const originalPrecision = bigNumberAmount.precision()
+  const decimalPlaces = bigNumberAmount.decimalPlaces()
 
-  const amount = new BN(bigNumberAmount
-    .multipliedBy(TEN_BIG_NUMBER
-      .pow(originalPrecision))
-    .integerValue()
-    .toString(10))
+  const amount = new BN(bigNumberAmount.multipliedBy(TEN_BIG_NUMBER.pow(decimalPlaces)).integerValue().toString(10))
 
-  const precision = originalPrecision + (amountPrecision as number)
+  const precision = decimalPlaces + amountPrecision
 
   return { amount, precision }
 }

--- a/test/utils/format/formatSmart.spec.ts
+++ b/test/utils/format/formatSmart.spec.ts
@@ -165,12 +165,12 @@ describe('0 decimals', () => {
 
 describe('Big amounts', () => {
   test('1B Ether', async () => {
-    expect(formatSmart(new BN(toWei(new BN('1000000000'), 'ether')), DEFAULT_PRECISION)).toEqual('1B')
+    expect(formatSmart(toWei(new BN('1000000000'), 'ether'), DEFAULT_PRECISION)).toEqual('1B')
   })
 
   test('uint max value', async () => {
     const expected = '115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665.64T'
-    expect(formatSmart(new BN(new BN(ALLOWANCE_MAX_VALUE)), DEFAULT_PRECISION)).toEqual(expected)
+    expect(formatSmart(new BN(ALLOWANCE_MAX_VALUE), DEFAULT_PRECISION)).toEqual(expected)
   })
 })
 
@@ -186,18 +186,42 @@ describe('Amount is a string', () => {
     const amount = '12345.67'
     expect(formatSmart(amount, 0)).toEqual('12,345.67')
   })
+
   test('12,345.6789 - More decimals than precision', () => {
-    const amount = '1234567.89'
+    const amount = '1234567.891'
     expect(formatSmart({ amount, precision: 2, decimals: 4 })).toEqual('12,345.6789')
   })
+
+  test('12,345 - No decimals, precision 0', () => {
+    const amount = '12345'
+    expect(formatSmart({ amount, precision: 0 })).toEqual('12,345')
+  })
+
+  test('1.2345 - No decimals, precision 4', () => {
+    const amount = '12345'
+    expect(formatSmart({ amount, precision: 4 })).toEqual('1.2345')
+  })
+
+  test('< 0.001 - No decimals, precision 0, tiny amount', () => {
+    const amount = '0.000001'
+    expect(formatSmart({ amount, precision: 0 })).toEqual('< 0.001')
+  })
+
+  test('1B - No decimals, precision 0, huge amount', () => {
+    const amount = '1000000000'
+    expect(formatSmart({ amount, precision: 0 })).toEqual('1B')
+  })
+
   test('0 - Zero string', () => {
     const amount = '0.00'
     expect(formatSmart(amount, 2)).toEqual('0')
   })
+
   test('null - Empty string', () => {
     const amount = ''
     expect(formatSmart(amount, 5)).toEqual(null)
   })
+
   test('null - Invalid string', () => {
     const amount = 'kfjasf'
     expect(formatSmart(amount, 6)).toEqual(null)

--- a/test/utils/format/formatSmart.spec.ts
+++ b/test/utils/format/formatSmart.spec.ts
@@ -180,3 +180,26 @@ describe('Edge cases', () => {
     expect(formatSmart({ amount, precision: 2, decimals: 4 })).toEqual('12,345.67')
   })
 })
+
+describe('Amount is a string', () => {
+  test('12,345.67 - Precision 0 (just adjust formatting)', () => {
+    const amount = '12345.67'
+    expect(formatSmart(amount, 0)).toEqual('12,345.67')
+  })
+  test('12,345.6789 - More decimals than precision', () => {
+    const amount = '1234567.89'
+    expect(formatSmart({ amount, precision: 2, decimals: 4 })).toEqual('12,345.6789')
+  })
+  test('0 - Zero string', () => {
+    const amount = '0.00'
+    expect(formatSmart(amount, 2)).toEqual('0')
+  })
+  test('null - Empty string', () => {
+    const amount = ''
+    expect(formatSmart(amount, 5)).toEqual(null)
+  })
+  test('null - Invalid string', () => {
+    const amount = 'kfjasf'
+    expect(formatSmart(amount, 6)).toEqual(null)
+  })
+})

--- a/test/utils/format/stringToBn.spec.ts
+++ b/test/utils/format/stringToBn.spec.ts
@@ -1,0 +1,101 @@
+import BN from 'bn.js'
+import { stringToBn, ZERO } from '../../../src'
+
+describe('With only required parameters', () => {
+  describe('invalid input', () => {
+    test('empty string', () => {
+      const response = { amount: null, precision: 0 }
+      expect(stringToBn('')).toEqual(response)
+    })
+
+    test('not a number', () => {
+      const response = { amount: null, precision: 0 }
+      expect(stringToBn('djas')).toEqual(response)
+    })
+  })
+
+  describe('zero', () => {
+    test('no decimals', () => {
+      const response = { amount: ZERO, precision: 0 }
+      expect(stringToBn('0')).toEqual(response)
+    })
+
+    test('with decimals', () => {
+      const response = { amount: ZERO, precision: 0 }
+      expect(stringToBn('0.000')).toEqual(response)
+    })
+  })
+
+  describe('regular', () => {
+    test('without decimals', () => {
+      const response = { amount: new BN('12345'), precision: 0 }
+      expect(stringToBn('12345')).toEqual(response)
+    })
+
+    test('decimals and integer', () => {
+      const response = { amount: new BN('12345'), precision: 2 }
+      expect(stringToBn('123.45')).toEqual(response)
+    })
+
+    test('only decimals', () => {
+      const response = { amount: new BN('12345'), precision: 5 }
+      expect(stringToBn('0.12345')).toEqual(response)
+    })
+  })
+})
+describe('With optional parameters', () => {
+  describe('precision 0', () => {
+    describe('invalid input', () => {
+      test('empty string', () => {
+        const response = { amount: null, precision: 0 }
+        expect(stringToBn('', 0)).toEqual(response)
+      })
+
+      test('not a number', () => {
+        const response = { amount: null, precision: 0 }
+        expect(stringToBn('djas', 0)).toEqual(response)
+      })
+    })
+
+    describe('zero', () => {
+      test('no decimals', () => {
+        const response = { amount: ZERO, precision: 0 }
+        expect(stringToBn('0', 0)).toEqual(response)
+      })
+
+      test('with decimals', () => {
+        const response = { amount: ZERO, precision: 0 }
+        expect(stringToBn('0.000', 0)).toEqual(response)
+      })
+    })
+
+    describe('regular', () => {
+      test('without decimals', () => {
+        const response = { amount: new BN('12345'), precision: 0 }
+        expect(stringToBn('12345', 0)).toEqual(response)
+      })
+
+      test('decimals and integer', () => {
+        const response = { amount: new BN('12345'), precision: 2 }
+        expect(stringToBn('123.45', 0)).toEqual(response)
+      })
+
+      test('only decimals', () => {
+        const response = { amount: new BN('12345'), precision: 5 }
+        expect(stringToBn('0.12345', 0)).toEqual(response)
+      })
+    })
+  })
+
+  describe('precision 1', () => {
+    test('input already has decimals', () => {
+      const response = { amount: new BN('12345'), precision: 3 }
+      expect(stringToBn('123.45', 1)).toEqual(response)
+    })
+
+    test('integer input', () => {
+      const response = { amount: new BN('12345'), precision: 1 }
+      expect(stringToBn('12345', 1)).toEqual(response)
+    })
+  })
+})


### PR DESCRIPTION
# Update 2020-11-10

Exposing `stringToBn` function.
Plus addressing comments.

---

# Summary

On `format*` utils functions, I'd like to pass a number as a string and receive the properly formatted number as string back, without having to convert it to a BN first.
I may or may not need additional precision adjustment.

## Example:

``` typescript
formatSmart('0.000001', 0) // => '< 0.001'
``` 

## Background

We originally developed these helper functions to deal with BNs and wei/unit conversions.
On CMM app we are using [Decimal js](https://mikemcl.github.io/decimal.js) and if I want to use these nice functions I need to go a long way converting values from Decimal -> string -> BN, which is a bit annoying as this implementation shows. (Unless, there's a better way?)

See for instance a wrapper I created around `formatSmart` -> https://github.com/gnosis/safe-cmm-app-react/blob/b951c76f580358b9dbe507140c63fdfdaf2abb9f/src/utils/format.ts

So I'm proposing making all functions accept the amount as string, to make it number library agnostic.
I'm not going to remove BN from the input for backwards compatibility, but maybe we should consider a breaking change in the future to unify the BN|BigNumber|Decimal mess we have =P

