### PR TITLE
[Feature] thousand separator for format smart

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -72,9 +72,10 @@ function _formatSmart(
   { integerPart, decimalPart, decimalsPadded }: DecomposedNumberParts,
   smallLimit: string,
   isLocaleAware: boolean,
+  thousandSeparator?: boolean,
 ): string {
   const decimalsSymbol = isLocaleAware ? DECIMALS_SYMBOL : DEFAULT_DECIMALS_SYMBOL
-  const thousandsSymbol = isLocaleAware ? THOUSANDS_SYMBOL : DEFAULT_THOUSANDS_SYMBOL
+  const thousandsSymbol = !thousandSeparator ? '' : isLocaleAware ? THOUSANDS_SYMBOL : DEFAULT_THOUSANDS_SYMBOL
 
   // Is < 1
   if (integerPart.isZero()) {
@@ -177,7 +178,7 @@ export function stringToBn(amountStr: string, additionalPrecision = 0): { amount
   return { amount, precision }
 }
 
-interface SmartFormatParams<T> extends Exclude<FormatAmountParams<T>, 'thousandSeparator'> {
+interface SmartFormatParams<T> extends FormatAmountParams<T> {
   smallLimit?: string
 }
 
@@ -213,6 +214,7 @@ export function formatSmart(
   // `isLocaleAware` defaults to true for backwards compatibility,
   // as it was the standard behaviour before this change
   let isLocaleAware = true
+  let thousandSeparator = true
 
   if (
     !params ||
@@ -251,6 +253,7 @@ export function formatSmart(
     decimals = params.decimals ?? decimals
     smallLimit = params.smallLimit ?? smallLimit
     isLocaleAware = params.isLocaleAware ?? isLocaleAware
+    thousandSeparator = params.thousandSeparator === undefined ? thousandSeparator : params.thousandSeparator
   }
 
   // amount is already zero
@@ -258,7 +261,7 @@ export function formatSmart(
 
   const actualDecimals = Math.min(precision, decimals)
   const numberParts = _decomposeBn(amount, precision, actualDecimals)
-  return _formatSmart(numberParts, smallLimit, isLocaleAware)
+  return _formatSmart(numberParts, smallLimit, isLocaleAware, thousandSeparator)
 }
 
 interface FormatAmountParams<T> {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -253,7 +253,7 @@ export function formatSmart(
     decimals = params.decimals ?? decimals
     smallLimit = params.smallLimit ?? smallLimit
     isLocaleAware = params.isLocaleAware ?? isLocaleAware
-    thousandSeparator = params.thousandSeparator === undefined ? thousandSeparator : params.thousandSeparator
+    thousandSeparator = params.thousandSeparator ?? thousandSeparator
   }
 
   // amount is already zero

--- a/test/utils/format/formatSmart.spec.ts
+++ b/test/utils/format/formatSmart.spec.ts
@@ -255,3 +255,23 @@ describe('Non-standard locale', () => {
     expect(formatSmart({ amount, precision: 2, decimals: 4, isLocaleAware: false })).toEqual('12,345.6789')
   })
 })
+
+describe('Thousand separator option', () => {
+  beforeEach(() => {
+    Object.defineProperty(constants, 'DECIMALS_SYMBOL', { value: ',' })
+    Object.defineProperty(constants, 'THOUSANDS_SYMBOL', { value: '.' })
+  })
+
+  test('Shows thousand separator by default', () => {
+    const amount = '1234567.891'
+    expect(formatSmart({ amount, precision: 2, decimals: 4 })).toEqual('12.345,6789')
+  })
+  test('Explicitly set thousandSeparator TRUE and it shows', () => {
+    const amount = '1234567.891'
+    expect(formatSmart({ amount, precision: 2, decimals: 4, thousandSeparator: true })).toEqual('12.345,6789')
+  })
+  test('Explicitly set thousandSeparator FALSE and it doesnt show', () => {
+    const amount = '1234567.891'
+    expect(formatSmart({ amount, precision: 2, decimals: 4, thousandSeparator: false })).toEqual('12345,6789')
+  })
+})


### PR DESCRIPTION
`formatSmart` was auto setting the `thousandSeparator` so it wasn't possible to remove it
e.g `12345.123` could not be a valid return previously without doing some external string manipulation after the fact.

Now it is!

Complete with tests to prove it.