### PR TITLE
Cowswap 1316/trailling dot

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -131,7 +131,7 @@ function _formatSmart(
 
   const amountBeforePrecisionCheck =
     _formatNumber(integerPart.toString(10), thousandsSymbol) + decimalsSymbol + decimalsPadded
-  return `${sign}${adjustPrecision(amountBeforePrecisionCheck, finalPrecision, decimalsSymbol).replace(/0+$/, '')}`
+  return `${sign}${adjustPrecision(amountBeforePrecisionCheck, finalPrecision, decimalsSymbol).replace(/\.?0*$/, '')}`
 }
 
 function _decomposeBn(

--- a/test/utils/format/formatSmart.spec.ts
+++ b/test/utils/format/formatSmart.spec.ts
@@ -194,6 +194,11 @@ describe('Edge cases', () => {
     const amount = new BN('1234567')
     expect(formatSmart({ amount, precision: 2, decimals: 4 })).toEqual('12,345.67')
   })
+
+  test('Do not return values with trailing dots', () => {
+    const amount = '353276954043779'
+    expect(formatSmart({ amount, precision: 6, decimals: 4, smallLimit: '0.0001', thousandSeparator: false, isLocaleAware: false })).toEqual('353276954')
+  })
 })
 
 describe('Amount is a string', () => {


### PR DESCRIPTION
# Summary

Part of https://github.com/gnosis/cowswap/issues/1316

Do not return values with trailing dots

![Screenshot from 2021-12-02 16-11-41](https://user-images.githubusercontent.com/43217/144522749-4c4e12d2-de8c-440f-ae0a-2f0ba5ca4bfa.png)


# Testing

- Unit test
- Locally added to CowSwap the updated lib

