### PR TITLE
Bumping bignumberjs to latest to sync with cowswap

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@gnosis.pm/dex-contracts": "^0.5.0",
-    "bignumber.js": "^9.0.0"
+    "bignumber.js": "^9.0.2"
   },
   "devDependencies": {
     "@typechain/web3-v1": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1434,6 +1434,11 @@ bignumber.js@*, bignumber.js@^9.0.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
   integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
+bignumber.js@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
+  integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
+
 binary-extensions@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"


### PR DESCRIPTION
# Summary

Having issues since bignumber.js versions have differed on CowSwap and dex-js

![Screenshot from 2021-12-15 09-44-55](https://user-images.githubusercontent.com/43217/146208481-75a2b445-01bf-43db-9440-7a50a825e7cb.png)

Bumping this to latest and will do the same on CowSwap

# Testing

Tested using YALC locally